### PR TITLE
add unique index to plans table

### DIFF
--- a/db/migrate/20170530115506_create_plans.rb
+++ b/db/migrate/20170530115506_create_plans.rb
@@ -16,5 +16,17 @@ class CreatePlans < ActiveRecord::Migration[5.0]
     add_index(:plans, :agent_id)
     add_index(:plans, :location_start, using: 'gist')
     add_index(:plans, :location_end, using: 'gist')
+    add_index(:plans,
+      [
+        :agent_id,
+        :started_at,
+        :ended_at,
+        :from_activity_type,
+        :to_activity_type,
+        :location_start,
+        :location_end,
+        :mode,
+        :scenario_id
+      ], unique: true, name: 'index_plans_validation_unique')
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -36,6 +36,7 @@ ActiveRecord::Schema.define(version: 20170614113316) do
     t.geography "location_end",       limit: {:srid=>4326, :type=>"st_point", :geographic=>true}, null: false
     t.string    "mode",                                                                           null: false
     t.string    "scenario_id",                                                                    null: false
+    t.index ["agent_id", "started_at", "ended_at", "from_activity_type", "to_activity_type", "location_start", "location_end", "mode", "scenario_id"], name: "index_plans_validation_unique", unique: true, using: :btree
     t.index ["agent_id"], name: "index_plans_on_agent_id", using: :btree
     t.index ["location_end"], name: "index_plans_on_location_end", using: :gist
     t.index ["location_start"], name: "index_plans_on_location_start", using: :gist


### PR DESCRIPTION
please have a look. hier ein vorschlag für einen unique index auf der plans tabelle. bitte einmal reinschauen, aber die kombination über fast alle columns sollte sicherstellen, dass keine plans mehrfach erzeugt werden können. @kjoscha  @dhosse 